### PR TITLE
Allow UTF-8 and international characters injection on linux (x11 and Wayland) via `xdotool` and `wtype`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-`clipboard-paste-keyboard` is a cross-platform command-line tool to write clipboard content using the keyboard. It can be used to write the clipboard content through RDS, or any software that disable pasting (Ctrl + V).
+`clipboard-paste-keyboard` is a cross-platform command-line tool to write clipboard content using the keyboard. It can be used to write the clipboard content through RDS, or any software that disables pasting (Ctrl + V). On X11 and Wayland should also be able to paste international (UTF-8 characters).
 
 ## Platforms
 
@@ -15,7 +15,10 @@
 
 ## Requirements
 
-Linux and Unix platforms requires 'xclip' or 'xsel' command to be installed.
+Linux and Unix platforms requires following commands to be installed:
+- `xclip`, `xsel` - "the fallback way" - doesn't support international and UTF-8 characters 
+- `xdotool` - if you are running X11, supports international and UTF-8 characters
+- `wtype` - if you are running Wayland, supports international and UTF-8 characters
 
 ## How to use
 

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"log"
 	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 
 	"git.tcp.direct/kayos/sendkeys"
@@ -44,10 +48,88 @@ func writeClipboard(c *cli.Context) {
 		log.Fatal(err)
 	}
 
+	// Normalize line endings (keeps multiline behavior consistent)
+	content = normalizeNewlines(content)
+
+	// --- Linux: choose method based on session type (not tool presence) ---
+	if runtime.GOOS == "linux" {
+		switch detectLinuxSessionType() {
+		case "x11":
+			// Only in X11 session do we try xdotool.
+			if err := tryXdotoolType(content); err == nil {
+				return
+			}
+		case "wayland":
+			// Only in Wayland session do we try wtype.
+			if err := tryWtype(content); err == nil {
+				return
+			}
+		}
+		// otherwise fall through to sendkeys
+	}
+
+	// Fallback: original behavior (unchanged for Windows) 
 	kb, err := sendkeys.NewKBWrapWithOptions(sendkeys.Noisy)
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	kb.Type(content)
+}
+
+func normalizeNewlines(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}
+
+// detectLinuxSessionType returns "wayland", "x11", or "unknown".
+func detectLinuxSessionType() string {
+	// Most reliable hint:
+	// - XDG_SESSION_TYPE=wayland|x11
+	// Also:
+	// - WAYLAND_DISPLAY set => wayland
+	// - DISPLAY set (and not Wayland) => x11
+	t := strings.ToLower(strings.TrimSpace(os.Getenv("XDG_SESSION_TYPE")))
+	if t == "wayland" || os.Getenv("WAYLAND_DISPLAY") != "" {
+		return "wayland"
+	}
+	if t == "x11" || os.Getenv("DISPLAY") != "" {
+		return "x11"
+	}
+	return "unknown"
+}
+
+func tryXdotoolType(text string) error {
+	xdotoolPath, err := exec.LookPath("xdotool")
+	if err != nil {
+		return err
+	}
+
+	// xdotool type --file - reads text from stdin (UTF-8 if locale is UTF-8)
+	cmd := exec.Command(xdotoolPath, "type", "--clearmodifiers", "--file", "-")
+	cmd.Stdin = bytes.NewBufferString(text)
+
+	// Force UTF-8 locale to avoid encoding issues
+	cmd.Env = append(os.Environ(), "LC_ALL=C.UTF-8", "LANG=C.UTF-8")
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func tryWtype(text string) error {
+	wtypePath, err := exec.LookPath("wtype")
+	if err != nil {
+		return err
+	}
+
+	// wtype - reads text from stdin
+	cmd := exec.Command(wtypePath, "-")
+	cmd.Stdin = bytes.NewBufferString(text)
+
+	cmd.Env = append(os.Environ(), "LC_ALL=C.UTF-8", "LANG=C.UTF-8")
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }


### PR DESCRIPTION
On Linux the code was not able to paste international characters and extra UTF-8 characters. When such are used simply does nothing. Modified to support this via `xdotool` for X11 Linux and `wtype` for Wayland in Linux. Left original and windows same as it was  