### PR TITLE
Ensure build on every make run. Ensure delay option is visible on the help screen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: build
 build:
 	GOOS=windows GOARCH=amd64 go build -o bin/cbpk-amd64.exe # 64-bit
 	GOOS=windows GOARCH=386 go build -o bin/cbpk-386.exe # 32-bit

--- a/main.go
+++ b/main.go
@@ -22,10 +22,13 @@ func main() {
 
 	cmd.Commands = []cli.Command{
 		{
-			Name: "write",
+			Name:        "write",
+			Usage:       "types clipboard content via simulated keystrokes (--delay N to wait N seconds)",
+			Description: "Use --delay N to wait N seconds before typing begins",
 			Flags: []cli.Flag{
 				cli.IntFlag{
 					Name:     "delay",
+					Usage:    "number of seconds to wait before typing begins",
 					Required: false,
 				},
 			},
@@ -69,7 +72,7 @@ func writeClipboard(c *cli.Context) {
 		// otherwise fall through to sendkeys
 	}
 
-	// Fallback: original behavior (unchanged for Windows) 
+	// Fallback: original behavior (unchanged for Windows)
 	kb, err := sendkeys.NewKBWrapWithOptions(sendkeys.Noisy)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
- Ensure rebuild on every make run. 
- Ensure delay option is visible on the help screen